### PR TITLE
Add docker command to allow use of WordPress's 'wp-env'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Example configuration in your `settings.json`:
 }
 ```
 
+## Example Using With wp-env
+
+An example of usign WordPress's wp-env:
+```json
+{
+    "pestphp.docker.enabled": true,
+    "pestphp.docker.command": "wp-env run tests-cli --env-cwd=wp-content/plugins/my-test-plugin"
+}
+```
+
 ## Supported OS
 
 This extension has been tested and confirmed to work on the following operating systems:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ These features are designed to streamline your testing process, making it more e
 
 You can configure the extension to use Docker and update the PEST PHP path. The configuration is in JSON format with the following keys:
 
+- `pestphp.docker.command`: Docker command to be used to run the command inside. Default is `docker exec`.
 - `pestphp.docker.container_name`: The name of the Docker container where PEST PHP is installed.
 - `pestphp.path`: The path to the PEST PHP executable.
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
         "configuration": {
             "title": "Pest PHP test framework",
             "properties": {
+                "pestphp.docker.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable Docker support."
+                },
+                "pestphp.docker.command": {
+                    "type": "string",
+                    "default": "docker exec",
+                    "description": "Docker command to be used to run the command inside."
+                },
                 "pestphp.docker.container_name": {
                     "type": [
                         "string",
@@ -50,7 +60,14 @@
                     "description": "Custom path to run the command. Ex: `vendor/bin/pest`."
                 }
             }
-        }
+        },
+        "commands": [
+            {
+                "command": "pestphp.mytest",
+                "title": "Pest PHP: My Test Command",
+                "category": "Pest PHP"
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "yarn run package",

--- a/package.json
+++ b/package.json
@@ -60,14 +60,7 @@
                     "description": "Custom path to run the command. Ex: `vendor/bin/pest`."
                 }
             }
-        },
-        "commands": [
-            {
-                "command": "pestphp.mytest",
-                "title": "Pest PHP: My Test Command",
-                "category": "Pest PHP"
-            }
-        ]
+        }
     },
     "scripts": {
         "vscode:prepublish": "yarn run package",

--- a/src/Controllers/ParentParser.ts
+++ b/src/Controllers/ParentParser.ts
@@ -88,7 +88,7 @@ export default class ParentParser {
         let command: string = '';
 
         if (configs.isDockerEnabled) {
-            command += `docker exec ${configs.dockerConatinerName} `;
+            command += `${configs.dockerCommand} ${configs.dockerConatinerName} `;
         }
 
         command += `${configs.path} ${fileUrl ?? ''} --list-tests`;

--- a/src/Controllers/TestCommandHandler.ts
+++ b/src/Controllers/TestCommandHandler.ts
@@ -1,4 +1,5 @@
-import { spawn } from "child_process";
+// import { spawn } from "child_process";
+import * as cp from 'child_process';
 import { TestController, TestItem, TestRun, TestRunRequest, WorkspaceFolder, workspace } from "vscode";
 import { default as configs } from "../configs";
 import { EOL, ItemType, getTestInfo } from "../utils";
@@ -65,10 +66,11 @@ export default class TestCommandHandler {
                 .replace(/\//g, '\\');
             }
 
-            const command = spawn(finalCmdPrefix, finalArgs, { cwd: currentWorkingDirectory });
-            this.runner.appendOutput(`🚀 ${command.spawnargs.filter(value => value !== '--teamcity' && value !== '--colors=never').join(' ')}${EOL}`);
+            // 'spawn' did not work. Needed 'exec'. Likely needed a shell
+            const command = cp.exec(finalCmdPrefix + ' ' + finalArgs.join(' '), { cwd: currentWorkingDirectory });
+            this.runner.appendOutput(`🚀 ${command.spawnargs.join(' ')}${EOL}`);
 
-            command.stdout.on('data', (data) => {
+            command.stdout?.on('data', (data) => {
                 const output = data.toString();
                 const lines = output.split(/\r\n|\n/);
 
@@ -92,8 +94,20 @@ export default class TestCommandHandler {
                     }
                 }
             });
-            
-            command.stdout.on('end', () => { this.runner.end() });
+
+            command.stderr?.on('data', (data) => {
+                const output = data.toString();
+                const lines = output.split(/\r\n|\n/);
+
+                while (lines.length > 1) {
+                    const line: string = lines.shift();
+                    this.runner.appendOutput(`${line}${EOL}`);
+                }
+            });
+
+            command.stdout?.on('end', () => {
+                this.runner.end();
+            });
         })
     }
 
@@ -101,7 +115,8 @@ export default class TestCommandHandler {
         let args: string[] = [];
 
         if (configs.isDockerEnabled) {
-            args.push('docker', 'exec', configs.dockerConatinerName);
+            const dockerCommand = configs.dockerCommand.split(' ');
+            args.push(...dockerCommand, configs.dockerConatinerName);
         }
 
         args.push(configs.path);
@@ -110,15 +125,15 @@ export default class TestCommandHandler {
             this.parentPaths.forEach(path => args.push(path));
         }
 
-        args.push('--teamcity')
-        args.push('--colors=never')
+        args.push('--teamcity');
+        args.push('--colors=never');
 
         if (this.testCases.length) {
-            args.push('--filter')
-            this.testCases.forEach(testCase => args.push(`'${testCase}'`))
+            args.push('--filter');
+            this.testCases.forEach(testCase => args.push(`'${testCase}'`));
         }
 
-        return args
+        return args;
     }
 
     private matchExperssions(line: string): { [key in regexPatternKeys]: RegExpMatchArray | null } {

--- a/src/Controllers/TestCommandHandler.ts
+++ b/src/Controllers/TestCommandHandler.ts
@@ -66,7 +66,7 @@ export default class TestCommandHandler {
                 .replace(/\//g, '\\');
             }
 
-            // 'spawn' did not work. Needed 'exec'. Likely needed a shell
+            // 'spawn' was resulting in the error 'Command failed with exit code 126', using exec resolved the issue.
             const command = cp.exec(finalCmdPrefix + ' ' + finalArgs.join(' '), { cwd: currentWorkingDirectory });
             this.runner.appendOutput(`🚀 ${command.spawnargs.join(' ')}${EOL}`);
 

--- a/src/Controllers/TestCommandHandler.ts
+++ b/src/Controllers/TestCommandHandler.ts
@@ -1,4 +1,3 @@
-// import { spawn } from "child_process";
 import * as cp from 'child_process';
 import { TestController, TestItem, TestRun, TestRunRequest, WorkspaceFolder, workspace } from "vscode";
 import { default as configs } from "../configs";

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -4,7 +4,13 @@ let packageConfig: vscode.WorkspaceConfiguration;
 
 export default {
     get isDockerEnabled(): boolean {
-        return packageConfig.get('docker.container_name') !== undefined && packageConfig.get('docker.container_name') !== null;
+        return (packageConfig.get('docker.enabled') !== undefined
+            && packageConfig.get('docker.enabled') !== null)
+            || (packageConfig.get('docker.command') !== undefined
+                && packageConfig.get('docker.command') !== null);
+    },
+    get dockerCommand(): string {
+        return packageConfig.get('docker.command') ?? 'docker exec';
     },
     get dockerConatinerName(): string {
         return packageConfig.get('docker.container_name') ?? '';


### PR DESCRIPTION
I opened https://github.com/shreifelagamy/vscode-pestphp/issues/7 yesterday, and you replied this morning. Interested in how it works, I started poking around, which turned into me making the needed changes. Woohoo!

Added configuration properties:
* `pestphp.docker.command`: Defaults to 'docker exec' which is what the system always used previously.
* `pestphp.docker.enabled`: Previously, docker would auto-enable if `pestphp.docker.container_name` was set. That is still true but now you can explicitly enable it.

Also
* An example of using this with wp-env was added to README.md.
* TestCommandHandler.ts was using `spawn`, which resulted in 'Command failed with exit code 126'. Using `exec` resolved the problem.
* I also modified the line that displayed the command ran to not remove '--teamcity' and '--colors=never'.  Adding them back would of course, be fine, but I modified the line because seeing the exact command was helpful when debugging.

Thanks!
David