### PR TITLE
fix(): Add option to opt out of WSL on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,94 +1,99 @@
 {
-    "name": "vscode-pestphp",
-    "displayName": "Pest PHP test explorer framework",
-    "description": "Enable the support for the pest testing framework ",
-    "icon": "assets/logo.png",
-    "version": "1.4.0",
-    "license": "MIT",
-    "publisher": "shashraf",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/shreifelagamy/vscode-pestphp"
-    },
-    "engines": {
-        "vscode": "^1.85.0"
-    },
-    "categories": [
-        "Testing",
-        "Other",
-        "Debuggers"
-    ],
-    "keywords": [
-        "pest",
-        "testing",
-        "php",
-        "laravel",
-        "pestphp",
-        "tdd",
-        "unittest",
-        "unit test"
-    ],
-    "activationEvents": [
-        "workspaceContains:**/*.php"
-    ],
-    "main": "./dist/extension.js",
-    "contributes": {
-        "configuration": {
-            "title": "Pest PHP test framework",
-            "properties": {
-                "pestphp.docker.enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enable Docker support."
-                },
-                "pestphp.docker.command": {
-                    "type": "string",
-                    "default": "docker exec",
-                    "description": "Docker command to be used to run the command inside."
-                },
-                "pestphp.docker.container_name": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "Docker container name to be used to run the command inside ."
-                },
-                "pestphp.path": {
-                    "type": "string",
-                    "default": "./vendor/bin/pest",
-                    "description": "Custom path to run the command. Ex: `vendor/bin/pest`."
-                }
-            }
-        }
-    },
-    "scripts": {
-        "vscode:prepublish": "yarn run package",
-        "compile": "webpack",
-        "watch": "webpack --watch",
-        "package": "webpack --mode production --devtool hidden-source-map",
-        "compile-tests": "tsc -p . --outDir out",
-        "watch-tests": "tsc -p . -w --outDir out",
-        "pretest": "yarn run compile-tests && yarn run compile && yarn run lint",
-        "lint": "eslint src --ext ts",
-        "test": "node ./out/test/runTest.js"
-    },
-    "devDependencies": {
-        "@types/mocha": "^10.0.3",
-        "@types/node": "18.x",
-        "@types/vscode": "^1.85.0",
-        "@typescript-eslint/eslint-plugin": "^6.9.0",
-        "@typescript-eslint/parser": "^6.9.0",
-        "@vscode/test-electron": "^2.3.6",
-        "eslint": "^8.52.0",
-        "glob": "^10.3.10",
-        "mocha": "^10.2.0",
-        "ts-loader": "^9.5.0",
-        "typescript": "^5.2.2",
-        "webpack": "^5.89.0",
-        "webpack-cli": "^5.1.4"
-    },
-    "dependencies": {
-        "php-parser": "^3.1.5"
-    }
+	"name": "vscode-pestphp",
+	"displayName": "Pest PHP test explorer framework",
+	"description": "Enable the support for the pest testing framework ",
+	"icon": "assets/logo.png",
+	"version": "1.4.0",
+	"license": "MIT",
+	"publisher": "shashraf",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/shreifelagamy/vscode-pestphp"
+	},
+	"engines": {
+		"vscode": "^1.85.0"
+	},
+	"categories": [
+		"Testing",
+		"Other",
+		"Debuggers"
+	],
+	"keywords": [
+		"pest",
+		"testing",
+		"php",
+		"laravel",
+		"pestphp",
+		"tdd",
+		"unittest",
+		"unit test"
+	],
+	"activationEvents": [
+		"workspaceContains:**/*.php"
+	],
+	"main": "./dist/extension.js",
+	"contributes": {
+		"configuration": {
+			"title": "Pest PHP test framework",
+			"properties": {
+				"pestphp.wsl.enabled": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable WSL support."
+				},
+				"pestphp.docker.enabled": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enable Docker support."
+				},
+				"pestphp.docker.command": {
+					"type": "string",
+					"default": "docker exec",
+					"description": "Docker command to be used to run the command inside."
+				},
+				"pestphp.docker.container_name": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "Docker container name to be used to run the command inside ."
+				},
+				"pestphp.path": {
+					"type": "string",
+					"default": "./vendor/bin/pest",
+					"description": "Custom path to run the command. Ex: `vendor/bin/pest`."
+				}
+			}
+		}
+	},
+	"scripts": {
+		"vscode:prepublish": "yarn run package",
+		"compile": "webpack",
+		"watch": "webpack --watch",
+		"package": "webpack --mode production --devtool hidden-source-map",
+		"compile-tests": "tsc -p . --outDir out",
+		"watch-tests": "tsc -p . -w --outDir out",
+		"pretest": "yarn run compile-tests && yarn run compile && yarn run lint",
+		"lint": "eslint src --ext ts",
+		"test": "node ./out/test/runTest.js"
+	},
+	"devDependencies": {
+		"@types/mocha": "^10.0.3",
+		"@types/node": "18.x",
+		"@types/vscode": "^1.85.0",
+		"@typescript-eslint/eslint-plugin": "^6.9.0",
+		"@typescript-eslint/parser": "^6.9.0",
+		"@vscode/test-electron": "^2.3.6",
+		"eslint": "^8.52.0",
+		"glob": "^10.3.10",
+		"mocha": "^10.2.0",
+		"ts-loader": "^9.5.0",
+		"typescript": "^5.2.2",
+		"webpack": "^5.89.0",
+		"webpack-cli": "^5.1.4"
+	},
+	"dependencies": {
+		"php-parser": "^3.1.5"
+	}
 }

--- a/src/Controllers/ParentParser.ts
+++ b/src/Controllers/ParentParser.ts
@@ -29,13 +29,13 @@ export default class ParentParser {
     }
 
     async resolveTestParent(workspaceFolder: vscode.WorkspaceFolder, fileUrl?: string) {
-        let output
+        let output;
 
         const cmd = this.prepareCommand(fileUrl);
 
         const windowsOS = process.platform === 'win32';
 
-        let currentWorkingDirectory = workspaceFolder.uri.path
+        let currentWorkingDirectory = workspaceFolder.uri.path;
 
         if (windowsOS) {
             currentWorkingDirectory = workspaceFolder.uri.path
@@ -43,7 +43,7 @@ export default class ParentParser {
             .replace(/\//g, '\\'); // Replace forward slashes with backslashes
         }
 
-        const runningCommand = windowsOS ? `wsl ${cmd}` : `${cmd}`
+        const runningCommand = windowsOS && configs.isWslEnabled ? `wsl ${cmd}` : `${cmd}`;
 
         try {
             output = cp.execSync(runningCommand, { cwd: currentWorkingDirectory });
@@ -64,7 +64,7 @@ export default class ParentParser {
             if (!classNames.includes(theClassName)) {
                 const testPath = theClassName.replaceAll('\\', '/').replace('Tests/', 'tests/');
                 const fileUrl = `${testPath}.php`;
-                const uri = vscode.Uri.file(fileUrl)
+                const uri = vscode.Uri.file(fileUrl);
                 const ParentTestItem = this.controller.createTestItem(theClassName, theClassName, uri);
                 ParentTestItem.canResolveChildren = true;
 
@@ -75,7 +75,7 @@ export default class ParentParser {
                     testItem: ParentTestItem,
                     fileUrl: `${workspaceFolder.uri.path}/${testPath}.php`,
                     filePath: fileUrl
-                }
+                };
 
                 testData.set(ParentTestItem, info);
                 this.controller.items.add(ParentTestItem);
@@ -102,7 +102,7 @@ export default class ParentParser {
         watcher.onDidCreate(uri => {
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
             if (workspaceFolder) {
-                const fileUrl = path.relative(workspaceFolder.uri.fsPath, uri.fsPath)
+                const fileUrl = path.relative(workspaceFolder.uri.fsPath, uri.fsPath);
                 this.resolveTestParent(workspaceFolder, fileUrl);
             }
         });
@@ -131,7 +131,7 @@ export default class ParentParser {
                     parentTestItem = item;
                     return; // Exit the loop once the item is found
                 }
-            })
+            });
 
             // If the parent test item is found
             if (parentTestItem) {

--- a/src/Controllers/TestCommandHandler.ts
+++ b/src/Controllers/TestCommandHandler.ts
@@ -32,16 +32,16 @@ export default class TestCommandHandler {
                 const info = getTestInfo(testItem);
 
                 if (info.caseType == ItemType.File) {
-                    this.parentPaths.push(info.filePath)
+                    this.parentPaths.push(info.filePath);
                 } else if (info.caseType == ItemType.TestCase) {
-                    this.parentPaths.push(info.filePath)
-                    this.testCases.push(testItem.label)
+                    this.parentPaths.push(info.filePath);
+                    this.testCases.push(testItem.label);
                 }
 
                 this.workspace.push(info.workspaceFolder!);
             });
         } else {
-            this.workspace.push(...workspace.workspaceFolders!)
+            this.workspace.push(...workspace.workspaceFolders!);
         }
 
         this.runCommand();
@@ -53,8 +53,8 @@ export default class TestCommandHandler {
 
         const windowsOS = process.platform === 'win32';
 
-        const finalCmdPrefix = windowsOS ? 'wsl' : cmdPrefix;
-        const finalArgs = windowsOS ? [cmdPrefix, ...args] : args;
+        const finalCmdPrefix = windowsOS && configs.isWslEnabled ? 'wsl' : cmdPrefix;
+        const finalArgs = windowsOS && configs.isWslEnabled ? [cmdPrefix, ...args] : args;
 
         this.workspace.forEach(workspaceFolder => {
             let currentWorkingDirectory = workspaceFolder.uri.path;
@@ -83,13 +83,13 @@ export default class TestCommandHandler {
                     } else if (matchExp.testStartedPattern) {
                         testOutputHandler.testStarted(matchExp.testStartedPattern, matchExp.testDatasetStartedPattern!);
                     } else if (matchExp.testFailedPattern) {
-                        testOutputHandler.testFailed(matchExp.testFailedPattern)
+                        testOutputHandler.testFailed(matchExp.testFailedPattern);
                     } else if (matchExp.testSkippedPattern) {
-                        testOutputHandler.testSkipped(matchExp.testSkippedPattern)
+                        testOutputHandler.testSkipped(matchExp.testSkippedPattern);
                     } else if (matchExp.testFinishedPattern) {
-                        testOutputHandler.testFinished(matchExp.testFinishedPattern)
+                        testOutputHandler.testFinished(matchExp.testFinishedPattern);
                     } else if (matchExp.testSuiteFinishedPattern) {
-                        testOutputHandler.suiteFinished(matchExp.testSuiteFinishedPattern)
+                        testOutputHandler.suiteFinished(matchExp.testSuiteFinishedPattern);
                     }
                 }
             });
@@ -107,7 +107,7 @@ export default class TestCommandHandler {
             command.stdout?.on('end', () => {
                 this.runner.end();
             });
-        })
+        });
     }
 
     private prepareCommand(): string[] {

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,26 +1,29 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 let packageConfig: vscode.WorkspaceConfiguration;
 
 export default {
-    get isDockerEnabled(): boolean {
+	get isDockerEnabled(): boolean {
         return (packageConfig.get('docker.enabled') !== undefined
             && packageConfig.get('docker.enabled') !== null)
             || (packageConfig.get('docker.command') !== undefined
                 && packageConfig.get('docker.command') !== null);
     },
-    get dockerCommand(): string {
-        return packageConfig.get('docker.command') ?? 'docker exec';
-    },
-    get dockerConatinerName(): string {
-        return packageConfig.get('docker.container_name') ?? '';
-    },
-    get path(): string {
-        return packageConfig.get('path') ?? './vendor/bin/pest';
-    }
+	get isWslEnabled(): boolean {
+		return !!packageConfig.get('wsl.enabled');
+	},
+	get dockerCommand(): string {
+		return packageConfig.get("docker.command") ?? "docker exec";
+	},
+	get dockerConatinerName(): string {
+		return packageConfig.get("docker.container_name") ?? "";
+	},
+	get path(): string {
+		return packageConfig.get("path") ?? "./vendor/bin/pest";
+	},
 };
 
 export function loadConfigs() {
-    // Load configs here
-    packageConfig = vscode.workspace.getConfiguration('pestphp');
+	// Load configs here
+	packageConfig = vscode.workspace.getConfiguration("pestphp");
 }


### PR DESCRIPTION
Before this PR, when running on Windows, the extension would force the user to use WSL if they didn't want it to just fail on launch.

With this PR, people can choose whether they'll be using WSL or simply running the command directly on their OS like everyone else

Closes #9 